### PR TITLE
Fetch JSON for objects in a list of refids

### DIFF
--- a/static_aid/DataExtractor_ArchivesSpace.py
+++ b/static_aid/DataExtractor_ArchivesSpace.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import re
 import requests
 import sys
 

--- a/static_aid/config.py
+++ b/static_aid/config.py
@@ -83,6 +83,7 @@ dataExtractor['dataSource'] = dataExtractor.get('datasource', 'DEFAULT').lower()
 # baseURL, repository, user, password
 archivesSpace = _configSection('ArchivesSpace')
 if archivesSpace:
+    archivesSpace['base_url'] = archivesSpace.get('baseurl')
     archivesSpace['repository_url'] = '%s/repositories/%s' % (archivesSpace.get('baseurl'), archivesSpace.get('repository'))
     archivesSpace['breadcrumb_url'] = '%s/search/published_tree?node_uri=/repositories/%s' % (archivesSpace.get('baseurl'),
                                                                                               archivesSpace.get('repository'),


### PR DESCRIPTION
This adds another function to `DataExtractor_ArchivesSpace.py` which walks through a directory of assets and creates a list of refids based on their filenames. It then uses that list to search ArchivesSpace for those objects, and saves their JSON representations in a directory structure.