### PR TITLE
Remove GTM code and Replace with MTM code

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -26,15 +26,13 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}{{ site.baseurl }}/feed.xml" />
 
-  <!-- Google Analytics -->
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-10013579-6', 'auto');
-    ga('send', 'pageview');
-
-  </script>
+  <!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_lNmnBAi5.js'; s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
+  
 </head>

--- a/site/_layouts/catalogued-reports.html
+++ b/site/_layouts/catalogued-reports.html
@@ -29,6 +29,6 @@ layout: default
 
 <script>
 document.getElementById('download-button').addEventListener("click", function() {
-  ga('send', 'event', 'catalogued-reports', 'download', '{{object.title}}');
+  _paq.push(['trackEvent', 'catalogued-reports', 'download', '{{object.title}}']);
 });
 </script>

--- a/site/js/av.js
+++ b/site/js/av.js
@@ -33,31 +33,31 @@ window.onload = function() {
 		};
 
 		asset.addEventListener('play', function(){
-			ga('send', 'event', assetType, 'play', assetTitle);
+			_paq.push(['trackEvent', assetType, 'play', assetTitle]);
 		});
 
 		asset.addEventListener('pause', function(){
-			ga('send', 'event', assetType, 'pause', assetTitle);
+			_paq.push(['trackEvent', assetType, 'pause', assetTitle]);
 		});
 
 		asset.addEventListener('ended', function(){
-			ga('send', 'event', assetType, 'ended', assetTitle);
+			_paq.push(['trackEvent', assetType, 'ended', assetTitle]);
 		});
 
 		downloadButton.addEventListener("mousedown", function() {
-			ga('send', 'event', assetType, 'download', assetTitle);
+			_paq.push(['trackEvent', assetType, 'download', assetTitle]);
 		});
 
 		window.addEventListener("fullscreenchange", function( event ) {
-			ga('send', 'event', assetType, 'full screen', assetTitle);
+			_paq.push(['trackEvent', assetType, 'full screen', assetTitle]);
 		});
 
 		window.addEventListener("webkitfullscreenchange", function( event ) {
-			ga('send', 'event', assetType, 'full screen', assetTitle);
+			_paq.push(['trackEvent', assetType, 'full screen', assetTitle]);
 		});
 
 		window.addEventListener("mozfullscreenchange", function( event ) {
-			ga('send', 'event', assetType, 'full screen', assetTitle);
+			_paq.push(['trackEvent', assetType, 'full screen', assetTitle]);
 		});
 	}
 }

--- a/site/js/lunr-feed.js
+++ b/site/js/lunr-feed.js
@@ -37,8 +37,6 @@ $(document).ready(function() {
     $('#results').empty().append('<img class="mx-auto d-block" src="/img/loading.gif" />')
     $('#query').attr("value", searchTerm);
 
-    ga('send', 'event', searchType, 'search', searchTerm);
-
     $.getJSON("/"+searchType+"_search_index.json", function(data){
       let index = lunr.Index.load(data)
 

--- a/site/js/lunr-feed.js
+++ b/site/js/lunr-feed.js
@@ -37,6 +37,8 @@ $(document).ready(function() {
     $('#results').empty().append('<img class="mx-auto d-block" src="/img/loading.gif" />')
     $('#query').attr("value", searchTerm);
 
+    _paq.push(['trackEvent', searchType, 'search', searchTerm]);
+
     $.getJSON("/"+searchType+"_search_index.json", function(data){
       let index = lunr.Index.load(data)
 


### PR DESCRIPTION
Fixes #36 

Removes Google Tag Manager code and replaces with Matomo Tag code.

Also updates the Google Analytics (ga tags) event tracking to push event data to [Matomo (paq tags)](https://matomo.org/faq/reports/implement-event-tracking-with-matomo/) instead. We are currently only using Matomo Tag Manager for pageview data for this site, but we want to continue collecting the event data.